### PR TITLE
feat: open tab beside current tab without focus change

### DIFF
--- a/background.js
+++ b/background.js
@@ -89,8 +89,12 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
       
       if (address) {
         // Open Debank profile page
-        const debankUrl = `https://debank.com/profile/${address}`;
-        chrome.tabs.create({ url: debankUrl });
+        const debankUrl = `https://debank.com/profile/${address}?from=${selectedText}`;
+        chrome.tabs.create({ 
+          url: debankUrl, 
+          index: tab.index + 1,
+          active: false 
+        });
       } else {
         // Show error message
         chrome.scripting.executeScript({


### PR DESCRIPTION
- Set index and active properties in chrome.tabs.create() to open new tabs adjacent to current tab while preserving focus.
- Add the query which has ens name to identify the address